### PR TITLE
Use identifiers.org shortcodes for chembl

### DIFF
--- a/org.bridgedb.bio/resources/org/bridgedb/bio/datasources.txt
+++ b/org.bridgedb.bio/resources/org/bridgedb/bio/datasources.txt
@@ -8,7 +8,9 @@ BioSystems	Bs	http://www.ncbi.nlm.nih.gov/biosystems/	http://www.ncbi.nlm.nih.go
 BRENDA	Br	http://www.brenda-enzymes.org/	http://www.brenda-enzymes.org/php/result_flat.php4?ecno=$id	1.1.1.1	protein		1	urn:miriam:brenda	^((\d+\.-\.-\.-)|(\d+\.\d+\.-\.-)|(\d+\.\d+\.\d+\.-)|(\d+\.\d+\.\d+\.\d+))$	BRENDA
 CAS	Ca	http://commonchemistry.org	http://commonchemistry.org/ChemicalDetail.aspx?ref=$id	50-00-0	metabolite		1	urn:miriam:cas	^\d{1,7}\-\d{2}\-\d$	CAS
 CCDS	Cc	http://identifiers.org/ccds/	http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=ALLFIELDS&DATA=$id	CCDS33337	gene		0	urn:miriam:ccds	^CCDS\d+\.\d+$	Consensus CDS
-ChEMBL compound	Cl	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/compound/inspect/$id	CHEMBL308052	metabolite		1	urn:miriam:chembl.compound	^CHEMBL\d+$	ChEMBL compound
+ChEMBL compound	chembl.compound	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/compound/inspect/$id	CHEMBL308052	metabolite		1	urn:miriam:chembl.compound	^CHEMBL\d+$	ChEMBL compound
+ChEMBL target	chembl.target	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/target/inspect/$id	CHEMBL3467	unknown		1	urn:miriam:chembl.target	^CHEMBL\d+$				
+ChEMBL target component	chembl.targetcomponent	https://www.ebi.ac.uk/chembldb/	http://rdf.ebi.ac.uk/resource/chembl/targetcomponent/$id	CHEMBL_TC_3597	unknown		1			
 ChEBI	Ce	http://www.ebi.ac.uk/chebi/	http://www.ebi.ac.uk/chebi/searchId.do?chebiId=$id	CHEBI:36927	metabolite		1	urn:miriam:chebi	^CHEBI:\d+$	ChEBI
 Chemspider	Cs	http://www.chemspider.com/	http://www.chemspider.com/Chemical-Structure.$id.html	56586	metabolite		1	urn:miriam:chemspider	^\d+$	ChemSpider
 CodeLink	Ge	http://www.appliedmicroarrays.com/		GE86325	probe		0	Ge		CodeLink

--- a/org.bridgedb.bio/test/org/bridgedb/bio/DataSourceTxtTest.java
+++ b/org.bridgedb.bio/test/org/bridgedb/bio/DataSourceTxtTest.java
@@ -94,14 +94,24 @@ public class DataSourceTxtTest {
     }
 
     @Test
-    public void testChEMBL() throws Exception {
+    public void testChEMBLCompound() throws Exception {
     	DataSourceTxt.init();
     	DataSource wikidata = DataSource.getExistingByFullName("ChEMBL compound");
     	Assert.assertNotNull(wikidata);
     	Assert.assertTrue(wikidata.urlPatternKnown());
-    	Assert.assertEquals("Cl", wikidata.getSystemCode());
+    	Assert.assertEquals("chembl.compound", wikidata.getSystemCode());
     }
 
+    @Test
+    public void testChEMBLTarget() throws Exception {
+    	DataSourceTxt.init();
+    	DataSource wikidata = DataSource.getExistingByFullName("ChEMBL target");
+    	Assert.assertNotNull(wikidata);
+    	Assert.assertTrue(wikidata.urlPatternKnown());
+    	Assert.assertEquals("chembl.target", wikidata.getSystemCode());
+    }
+
+    
     @Test
     public void testKNApSAcK() throws Exception {
     	DataSourceTxt.init();

--- a/org.bridgedb.rdf/resources/DataSource.ttl
+++ b/org.bridgedb.rdf/resources/DataSource.ttl
@@ -137,7 +137,7 @@ bridgeDB:DataSource_ChemIDplus a bridgeDB:DataSource ;
 
 bridgeDB:DataSource_ChEMBL_compound a bridgeDB:DataSource ;
 	bridgeDB:fullName "ChEMBL compound" ;
-	bridgeDB:systemCode "Cl" ;
+	bridgeDB:systemCode "chembl.compound" ;
 	bridgeDB:mainUrl "https://www.ebi.ac.uk/chembldb/" ;
 	bridgeDB:idExample "CHEMBL308052" ;
 	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
@@ -174,7 +174,7 @@ bridgeDB:DataSource_Chembl_Protclass a bridgeDB:DataSource ;
 
 bridgeDB:DataSource_Chembl_Target a bridgeDB:DataSource ;
 	bridgeDB:fullName "Chembl Target" ;
-	bridgeDB:systemCode "ChemblTarget" ;
+	bridgeDB:systemCode "chembl.target" ;
 	bridgeDB:idExample "1" ;
 	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
 	bridgeDB:type "unknown" ;

--- a/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.ttl
+++ b/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.ttl
@@ -950,7 +950,7 @@ bridgeDB:DataSource_ChemBank a bridgeDB:DataSource ;
 
 bridgeDB:DataSource_ChEMBL_compound a bridgeDB:DataSource ;
 	bridgeDB:fullName "ChEMBL compound" ;
-	bridgeDB:systemCode "chembl.compound" ;
+	bridgeDB:systemCode "linkedchemistry.chembl.compound" ;
 	bridgeDB:mainUrl "https://www.ebi.ac.uk/chembldb/" ;
 	bridgeDB:idExample "CHEMBL308052" ;
 	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;

--- a/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.ttl
+++ b/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.ttl
@@ -950,7 +950,7 @@ bridgeDB:DataSource_ChemBank a bridgeDB:DataSource ;
 
 bridgeDB:DataSource_ChEMBL_compound a bridgeDB:DataSource ;
 	bridgeDB:fullName "ChEMBL compound" ;
-	bridgeDB:systemCode "Cl" ;
+	bridgeDB:systemCode "chembl.compound" ;
 	bridgeDB:mainUrl "https://www.ebi.ac.uk/chembldb/" ;
 	bridgeDB:idExample "CHEMBL308052" ;
 	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;

--- a/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.txt
+++ b/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.txt
@@ -81,7 +81,7 @@ CGSC Strain	cgsc		http://cgsc.biology.yale.edu/Strain.php?ID=$id	11042	unknown		
 CharProt	charprot		http://www.jcvi.org/charprotdb/index.cgi/view/$id	CH_001923	unknown		1	urn:miriam:charprot	^CH_\d+$	
 ChEBI	Ce	http://www.ebi.ac.uk/chebi/	http://www.ebi.ac.uk/chebi/searchId.do?chebiId=$id	CHEBI:36927	metabolite		1	urn:miriam:chebi	^CHEBI:\d+$	ChEBI
 ChemBank	chembank		http://chembank.broadinstitute.org/chemistry/viewMolecule.htm?cbid=$id	1000000	unknown		1	urn:miriam:chembank	^\d+$	
-ChEMBL compound	Cl	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/compound/inspect/$id	CHEMBL308052	metabolite		1	urn:miriam:chembl.compound	^CHEMBL\d+$	
+ChEMBL compound	chembl.compound	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/compound/inspect/$id	CHEMBL308052	metabolite		1	urn:miriam:chembl.compound	^CHEMBL\d+$	
 ChEMBL target	chembl.target		https://www.ebi.ac.uk/chembl/target/inspect/$id	CHEMBL3467	unknown		1	urn:miriam:chembl.target	^CHEMBL\d+$				
 ChEMBL target component	chembl.targetcomponent	https://www.ebi.ac.uk/chembldb/	http://rdf.ebi.ac.uk/resource/chembl/targetcomponent/$id	CHEMBL_TC_3597	unknown		1			
 LinkedChemistry ChEMBL molecule	linkedchemistry.chembl.molecule		http://linkedchemistry.info/chembl/molecule/m$id	1	unknown		1			


### PR DESCRIPTION
System code `Cl` changes to `chembl.compound` - meaning it's then obvious how to also add `chembl.target` to `datasources.txt` in `org.bridgedb.bio`. 

This change means the system codes match the identifiers.org - e.g. http://identifiers.org/chembl.compound/ and http://identifiers.org/chembl.target/ - avoiding confusion with http://identifiers.org/cl/ (Cell Type Ontology)

This fixes #16.

Would this be a breaking change?
