### PR TITLE
Map datasources_headers.txt to vocab. Close #18

### DIFF
--- a/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt
+++ b/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt
@@ -2,17 +2,17 @@
 #
 # The term "conventional", as found in the descriptions below, refers to established usage norms for the BridgeDb project.
 #
-# Tab-delimited table:
+# Tab-delimited table:				
 #
-# column	header	description	example_entry
-1	datasource_name	Conventional name for datasource	Affy
-2	system_code	Conventional 1-3 letter code for datasource	X
-3	website_url	URL to main webpage for datasource	http://www.affymetrix.com/
-4	linkout_pattern	URL pattern for constructing links to ID-specific datasource pages, using $id as substitution variable	https://www.affymetrix.com/LinkServlet?probeset=$id
-5	example_identifier	A valid example of a datasource identifier; may not be representative of all types of identifiers from a given resource	1851_s_at
-6	entity_identified	Type of entity (e.g., biological molecule or concept) identified by datasource	probe
-7	single_species	Specific species represented by datasource (latin genus species); blank if datasource represents more than one species	Homo sapiens
-8	identifier_type	Conventional usage type for datasource: 1 = primary identifiers (used to uniquely identify molecules or concepts; useful for identifying entities on a pathway; useful targets for mapping measurement data), 0 = secondary identifiers (used to annotate molecules or concepts; useful as secondary linkouts; useful sources for data/annotation mapping)	0
-9	uri	Official URI for datasource (e.g., from miriam); or repeat of system_code if unknown or unregistered	urn:miriam:affy.probeset
-10	regex	Regular expression capturing all possible identifiers as narrowly as possible for datasource (see miriam)	\d{4,}((_[asx])?_at)?
-11	official_name	Official name of datasource resource; useful as an end-user display name; useful in name resolution	Affymetrix Probeset
+# column	header	description	example_entry	@id
+1	datasource_name	Conventional name for datasource	Affy	http://vocabularies.bridgedb.org/ops#conventionalName
+2	system_code	Conventional 1-3 letter code for datasource	X	http://vocabularies.bridgedb.org/ops#systemCode
+3	website_url	URL to main webpage for datasource	http://www.affymetrix.com/	http://vocabularies.bridgedb.org/ops#mainUrl
+4	linkout_pattern	"URL pattern for constructing links to ID-specific datasource pages, using $id as substitution variable"	https://www.affymetrix.com/LinkServlet?probeset=$id	http://vocabularies.bridgedb.org/ops#UriPattern
+5	example_identifier	A valid example of a datasource identifier; may not be representative of all types of identifiers from a given resource	1851_s_at	http://vocabularies.bridgedb.org/ops#idExample
+6	entity_identified	"Type of entity (e.g., biological molecule or concept) identified by datasource"	probe	http://vocabularies.bridgedb.org/ops#type
+7	single_species	Specific species represented by datasource (latin genus species); blank if datasource represents more than one species	Homo sapiens	http://vocabularies.bridgedb.org/ops#aboutOrganism
+8	identifier_type	"Conventional usage type for datasource: 1 = primary identifiers (used to uniquely identify molecules or concepts; useful for identifying entities on a pathway; useful targets for mapping measurement data), 0 = secondary identifiers (used to annotate molecules or concepts; useful as secondary linkouts; useful sources for data/annotation mapping)"	0	http://vocabularies.bridgedb.org/ops#primary
+9	uri	"Official URI for datasource (e.g., from miriam); or repeat of system_code if unknown or unregistered"	urn:miriam:affy.probeset	@id
+10	regex	Regular expression capturing all possible identifiers as narrowly as possible for datasource (see miriam)	"\d{4,}((_[asx])?_at)?"	http://vocabularies.bridgedb.org/ops#IdentifiersOrgInfoPattern
+11	official_name	Official name of datasource resource; useful as an end-user display name; useful in name resolution	Affymetrix Probeset	http://vocabularies.bridgedb.org/ops#fullName

--- a/org.bridgedb.bio/resources/org/bridgedb/bio/jsonld-context.jsonld
+++ b/org.bridgedb.bio/resources/org/bridgedb/bio/jsonld-context.jsonld
@@ -1,0 +1,275 @@
+{
+  "@context": {
+    "@vocab": "http://vocabularies.bridgedb.org/ops#",
+    "id": "@id",
+    "type": "@type",
+    "Dataset": {
+      "@id": "void:Dataset",
+      "@type": "@id"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#EntityReference": {
+      "@type": "@id"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#EntityReference": {
+      "@type": "@id"
+    },
+    "biopax:EntityReference": {
+      "@type": "@id"
+    },
+    "EntityReference": {
+      "@id": "biopax:EntityReference",
+      "@type": "@id"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#entityReference": {
+      "@type": "@id"
+    },
+    "biopax:entityReference": {
+      "@type": "@id"
+    },
+    "entityReference": {
+      "@id": "biopax:entityReference",
+      "@type": "@id"
+    },
+    "xref": {
+      "@id": "biopax:xref",
+      "@type": "@id"
+    },
+    "SIO": {
+      "@id": "http://semanticscience.org/resource/",
+      "@type": "@vocab"
+    },
+    "http://identifiers.org/idot/alternatePrefix": {
+      "@type": "xsd:string"
+    },
+    "idot:alternatePrefix": {
+      "@type": "xsd:string"
+    },
+    "alternatePrefix": {
+      "@id": "idot:alternatePrefix",
+      "@type": "xsd:string"
+    },
+    "baseIri": "@base",
+    "biopax": {
+      "@id": "http://www.biopax.org/release/biopax-level3.owl#",
+      "@type": "@vocab"
+    },
+    "bridgeDbDatasourceHeaders": {
+      "@id": "https://github.com/bridgedb/BridgeDb/blob/master/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt#",
+      "@type": "@vocab"
+    },
+    "https://github.com/bridgedb/BridgeDb/blob/master/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt#datasource_name": {
+      "@type": "xsd:string"
+    },
+    "bridgeDbDatasourceHeaders:datasource_name": {
+      "@type": "xsd:string"
+    },
+    "datasource_name": {
+      "@id": "bridgeDbDatasourceHeaders:datasource_name",
+      "@type": "xsd:string"
+    },
+    "https://github.com/bridgedb/BridgeDb/blob/master/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt#linkout_pattern": {
+      "@type": "xsd:string"
+    },
+    "bridgeDbDatasourceHeaders:linkout_pattern": {
+      "@type": "xsd:string"
+    },
+    "linkout_pattern": {
+      "@id": "bridgeDbDatasourceHeaders:linkout_pattern",
+      "@type": "xsd:string"
+    },
+    "http://vocabularies.bridgedb.org/ops#type": {
+      "@type": "xsd:string"
+    },
+    "entityType": {
+      "@id": "http://vocabularies.bridgedb.org/ops#type",
+      "@type": "xsd:string"
+    },
+    "http://vocabularies.bridgedb.org/ops#primary": {
+      "@type": "xsd:string"
+    },
+    "primary": {
+      "@type": "xsd:string"
+    },
+    "http://vocabularies.bridgedb.org/ops#systemCode": {
+      "@type": "xsd:string"
+    },
+    "systemCode": {
+      "@type": "xsd:string"
+    },
+    "bridgeDbDatasourceHeaders:system_code": {
+      "@type": "xsd:string"
+    },
+    "system_code": {
+      "@id": "bridgeDbDatasourceHeaders:system_code",
+      "@type": "xsd:string"
+    },
+    "http://vocabularies.bridgedb.org/ops#uriRegexPattern": {
+      "@type": "xsd:string"
+    },
+    "uriRegexPattern": {
+      "@type": "xsd:string"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#db": {
+      "@type": "xsd:string"
+    },
+    "biopax:db": {
+      "@type": "xsd:string"
+    },
+    "db": {
+      "@id": "biopax:db",
+      "@type": "xsd:string"
+    },
+    "dcterms": {
+      "@id": "http://purl.org/dc/terms/",
+      "@type": "@vocab"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#displayName": {
+      "@type": "xsd:string"
+    },
+    "biopax:displayName": {
+      "@type": "xsd:string"
+    },
+    "displayName": {
+      "@id": "biopax:displayName",
+      "@type": "xsd:string"
+    },
+    "http://identifiers.org/idot/exampleIdentifier": {
+      "@type": "xsd:string"
+    },
+    "idot:exampleIdentifier": {
+      "@type": "xsd:string"
+    },
+    "exampleIdentifier": {
+      "@id": "idot:exampleIdentifier",
+      "@type": "xsd:string"
+    },
+    "http://rdfs.org/ns/void#exampleResource": {
+      "@type": "@id"
+    },
+    "void:exampleResource": {
+      "@type": "@id"
+    },
+    "exampleResource": {
+      "@id": "void:exampleResource",
+      "@type": "@id"
+    },
+    "foaf": {
+      "@id": "http://xmlns.com/foaf/0.1/",
+      "@type": "@vocab"
+    },
+    "gpml": {
+      "@id": "http://vocabularies.wikipathways.org/gpml#",
+      "@type": "@vocab"
+    },
+    "identifier": {
+      "@id": "http://rdaregistry.info/Elements/u/P60052",
+      "@type": "xsd:string"
+    },
+    "http://identifiers.org/idot/identifierPattern": {
+      "@type": "xsd:string"
+    },
+    "idot:identifierPattern": {
+      "@type": "xsd:string"
+    },
+    "identifierPattern": {
+      "@id": "idot:identifierPattern",
+      "@type": "xsd:string"
+    },
+    "idot": {
+      "@id": "http://identifiers.org/idot/",
+      "@type": "@vocab"
+    },
+    "isDataItemIn": {
+      "@id": "SIO:SIO_001278",
+      "@type": "@id"
+    },
+    "http://schema/name": {
+      "@type": "xsd:string"
+    },
+    "schema:name": {
+      "@type": "xsd:string"
+    },
+    "name": {
+      "@id": "schema:name",
+      "@type": "xsd:string"
+    },
+    "nameLanguageMap": {
+      "@container": "@language",
+      "@id": "name"
+    },
+    "http://www.biopax.org/release/biopax-level3.owl#organism": {
+      "@type": "@id"
+    },
+    "biopax:organism": {
+      "@type": "@id"
+    },
+    "organism": {
+      "@id": "biopax:organism",
+      "@type": "@id"
+    },
+    "owl": {
+      "@id": "http://www.w3.org/2002/07/owl#",
+      "@type": "@vocab"
+    },
+    "http://identifiers.org/idot/preferredPrefix": {
+      "@type": "xsd:string"
+    },
+    "idot:preferredPrefix": {
+      "@type": "xsd:string"
+    },
+    "preferredPrefix": {
+      "@id": "idot:preferredPrefix",
+      "@type": "xsd:string"
+    },
+    "probe": {
+      "@id": "http://www.sequenceontology.org/miso/release_2.4/term/SO:0000051",
+      "@type": "@id"
+    },
+    "schema": {
+      "@id": "http://schema.org/",
+      "@type": "@vocab"
+    },
+    "http://purl.org/dc/terms/subject": {
+      "@type": "@id"
+    },
+    "dcterms:subject": {
+      "@type": "@id"
+    },
+    "subject": {
+      "@id": "dcterms:subject",
+      "@type": "@id"
+    },
+    "https://github.com/bridgedb/BridgeDb/blob/master/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt#uri": {
+      "@type": "@id"
+    },
+    "bridgeDbDatasourceHeaders:uri": {
+      "@type": "@id"
+    },
+    "uri": {
+      "@id": "bridgeDbDatasourceHeaders:uri",
+      "@type": "@id"
+    },
+    "void": {
+      "@id": "http://rdfs.org/ns/void#",
+      "@type": "@vocab"
+    },
+    "https://github.com/bridgedb/BridgeDb/blob/master/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt#website_url": {
+      "@type": "@id"
+    },
+    "bridgeDbDatasourceHeaders:website_url": {
+      "@type": "@id"
+    },
+    "website_url": {
+      "@id": "bridgeDbDatasourceHeaders:website_url",
+      "@type": "@id"
+    },
+    "webPage": {
+      "@id": "foaf:page",
+      "@type": "@id"
+    },
+    "xsd": {
+      "@id": "http://www.w3.org/2001/XMLSchema#",
+      "@type": "@id"
+    }
+  }
+}


### PR DESCRIPTION
We've discussed wanting to map datasources_headers.txt to our vocabulary in #18. This commit adds the column `@id` to indicate the mapping.

See also the [pull request](https://github.com/bridgedb/vocabulary/pull/9) for the vocab.