### PR TITLE
Merge ops-2.2 into master.

### DIFF
--- a/org.bridgedb.rdf/resources/DataSource.ttl
+++ b/org.bridgedb.rdf/resources/DataSource.ttl
@@ -418,6 +418,7 @@ bridgeDB:DataSource_Ensembl a bridgeDB:DataSource ;
 	bridgeDB:hasUriPattern <http://www.ensembl.org/id/$id> ;
 	bridgeDB:hasIdentifiersOrgPattern <http://identifiers.org/ensembl/$id> ;
     bridgeDB:hasUriPattern <http://purl.uniprot.org/ensembl/$id> ;
+    bridgeDB:hasUriPattern <http://purl.uniprot.org/ensembl.transcript/$id> ;
     bridgeDB:hasUriPattern <http://rdf.ebi.ac.uk/resource/ensembl/$id> ;
 	bridgeDB:hasUriPattern <http://bio2rdf.org/ensembl:$id> .
 

--- a/org.bridgedb.rdf/resources/DataSource.ttl
+++ b/org.bridgedb.rdf/resources/DataSource.ttl
@@ -418,7 +418,7 @@ bridgeDB:DataSource_Ensembl a bridgeDB:DataSource ;
 	bridgeDB:hasUriPattern <http://www.ensembl.org/id/$id> ;
 	bridgeDB:hasIdentifiersOrgPattern <http://identifiers.org/ensembl/$id> ;
     bridgeDB:hasUriPattern <http://purl.uniprot.org/ensembl/$id> ;
-    bridgeDB:hasUriPattern <http://purl.uniprot.org/ensembl.transcript/$id> ;
+    bridgeDB:hasUriPattern <http://rdf.ebi.ac.uk/resource/ensembl.transcript/$id> ;
     bridgeDB:hasUriPattern <http://rdf.ebi.ac.uk/resource/ensembl/$id> ;
 	bridgeDB:hasUriPattern <http://bio2rdf.org/ensembl:$id> .
 

--- a/org.bridgedb.rdf/resources/DataSource.ttl
+++ b/org.bridgedb.rdf/resources/DataSource.ttl
@@ -418,6 +418,8 @@ bridgeDB:DataSource_Ensembl a bridgeDB:DataSource ;
 	bridgeDB:hasUriPattern <http://www.ensembl.org/id/$id> ;
 	bridgeDB:hasIdentifiersOrgPattern <http://identifiers.org/ensembl/$id> ;
     bridgeDB:hasUriPattern <http://purl.uniprot.org/ensembl/$id> ;
+    ## '.../ensembl.transcript/$id' pattern added to fix: https://github.com/bridgedb/BridgeDb/issues/43
+    ## '<http://www.ensembl.org/id/$id>' pattern likely obsolete, not in uniprot in May, 2017.
     bridgeDB:hasUriPattern <http://rdf.ebi.ac.uk/resource/ensembl.transcript/$id> ;
     bridgeDB:hasUriPattern <http://rdf.ebi.ac.uk/resource/ensembl/$id> ;
 	bridgeDB:hasUriPattern <http://bio2rdf.org/ensembl:$id> .

--- a/org.bridgedb.tools.batchmapper/pom.xml
+++ b/org.bridgedb.tools.batchmapper/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.bridgedb</groupId>
   <artifactId>org.bridgedb.tools.batchmapper</artifactId>
   <name>BridgeDb Batch Mapper</name>
-  
+
   <parent>
   	<artifactId>bridgedb-bundle</artifactId>
   	<groupId>org.bridgedb</groupId>
@@ -29,26 +29,26 @@
 			</testResource>
 		</testResources>
 	</build>
-	
+
 	<dependencies>
                 <dependency>
                         <groupId>org.bridgedb</groupId>
                         <artifactId>org.bridgedb</artifactId>
-                        <version>2.2.0</version>
+                        <version>2.2.0-SNAPSHOT</version>
                         <scope>compile</scope>
                 </dependency>
 		<dependency>
 			<groupId>org.bridgedb</groupId>
 			<artifactId>org.bridgedb.bio</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
                 <dependency>
                         <groupId>org.bridgedb</groupId>
                         <artifactId>org.bridgedb.rdb</artifactId>
-                        <version>2.2.0</version>
+                        <version>2.2.0-SNAPSHOT</version>
                         <scope>compile</scope>
                 </dependency>
 	</dependencies>
-  
+
 </project>

--- a/org.bridgedb.utils/resources/BridgeDb.properties
+++ b/org.bridgedb.utils/resources/BridgeDb.properties
@@ -6,7 +6,7 @@
 #It is HIGHLY RECOMMENDED to overwrite all relative directory paths!
 
 ###########Main SQL Database and user settings #######################
-SqlPort             jdbc:mysql://localhost:3006
+SqlPort             jdbc:mysql://localhost:3306
 SqlDatabase         ims
 SqlUser             ims
 SqlPassword         ims

--- a/org.bridgedb.webservice.uniprot/pom.xml
+++ b/org.bridgedb.webservice.uniprot/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.bridgedb.webservice</groupId>
   <artifactId>org.bridgedb.webservice.uniprot</artifactId>
   <name>BridgeDb Webservice UniProt</name>
-  
+
   <parent>
   	<artifactId>bridgedb-bundle</artifactId>
   	<groupId>org.bridgedb</groupId>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.bridgedb</groupId>
 			<artifactId>org.bridgedb.bio</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Merge the ops-2.2 branch into master and phase-out the ops-2.2 branch.

Fixed the missing URI pattern that was preventing load of Uniprot-->Ensembl Linkset during
openphacts v2.2 refresh.

Reverted mysql port back to standard mysql default of 3306.