### PR TITLE
Add AOP elements as data sources

### DIFF
--- a/org.bridgedb.bio/resources/org/bridgedb/bio/datasources.txt
+++ b/org.bridgedb.bio/resources/org/bridgedb/bio/datasources.txt
@@ -1,5 +1,9 @@
 Affy	X	http://www.affymetrix.com/	https://www.affymetrix.com/LinkServlet?probeset=$id	1851_s_at	probe		0	urn:miriam:affy.probeset	\d{4,}((_[asx])?_at)?	Affymetrix Probeset
 Agilent	Ag	http://agilent.com		A_24_P98555	probe		0	Ag	A_\d+_.+	Agilent
+AOP-Wiki KE     AopKe      https://aopwiki.org/    https://aopwiki.org/events/$id  3       unknown         1       urn:miriam:aop.events   ^\d+$   AOP-Wiki Key Events
+AOP-Wiki AOP    Aop     https://aopwiki.org/    https://aopwiki.org/aops/$id    3       pathway         1       urn:miriam:aop  ^\d+$   AOP-Wiki Adverse Outcome Pathway
+AOP-Wiki KER    AopKer      https://aopwiki.org/    https://aopwiki.org/relationships/$id   5       interaction             1       urn:miriam:aop.relationships    ^\d+$  $
+AOP-Wiki Stressor       AopS      https://aopwiki.org/    https://aopwiki.org/stressors/  222     metabolite              1       urn:miriam:aop.stressor ^\d+$   AOP-Wik$
 BIND	Bi	http://www.bind.ca/	http://www.bind.ca/Action?identifier=bindid&idsearch=$id		interaction		1	urn:miriam:bind	^\d+$	BIND
 BioCyc	Bc	http://biocyc.org	http://biocyc.org/getid?id=$id	ECOLI:CYT-D-UBIOX-CPLX	gene		1	urn:miriam:biocyc	^\w+\:[A-Za-z0-9-]+$	BioCyc
 BioGrid	Bg	http://thebiogrid.org/	http://thebiogrid.org/$id	31623	interaction		1	urn:miriam:biogrid	^\d+$	BioGRID

--- a/org.bridgedb.rdf/resources/BioDataSource.ttl
+++ b/org.bridgedb.rdf/resources/BioDataSource.ttl
@@ -1332,6 +1332,46 @@ bridgeDB:DataSource_ZFIN a bridgeDB:DataSource ;
 	bridgeDB:hasRegexPattern "ZDB\\-GENE\\-\\d+\\-\\d+" ;
 	dcterms:alternative "ZFIN Gene" .
 
+bridgeDB:DataSource_AOP-Wiki_Key_Events a bridgeDB:DataSource ;
+	bridgeDB:fullName "AOP-Wiki Key Event“ ;
+	bridgeDB:systemCode "AopKe" ;
+	bridgeDB:mainUrl "https://aopwiki.org/events" ;
+	bridgeDB:idExample "3" ;
+	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+	bridgeDB:type "pathway" ;
+	bridgeDB:hasRegexPattern "^\d+$" ;
+	dcterms:alternative "Key Event" .
+
+bridgeDB:DataSource_AOP-Wiki_Adverse_Outcome_Pathways a bridgeDB:DataSource ;
+	bridgeDB:fullName "AOP-Wiki Adverse Outcome Pathway" ;
+	bridgeDB:systemCode "Aop" ;
+	bridgeDB:mainUrl "https://aopwiki.org/aops" ;
+	bridgeDB:idExample "3" ;
+	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+	bridgeDB:type "pathway" ;
+	bridgeDB:hasRegexPattern "^\d+$" ;
+	dcterms:alternative "Adverse Outcome Pathway" .
+
+bridgeDB:DataSource_AOP-Wiki_Key_Event_Relationships a bridgeDB:DataSource ;
+	bridgeDB:fullName "AOP-Wiki Key Event Relationship" ;
+	bridgeDB:systemCode "AopKer" ;
+	bridgeDB:mainUrl "https://aopwiki.org/relationships" ;
+	bridgeDB:idExample "5" ;
+	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+	bridgeDB:type "interaction" ;
+	bridgeDB:hasRegexPattern "^\d+$" ;
+	dcterms:alternative "Key Event Relationship" .
+
+bridgeDB:DataSource_AOP-Wiki_Stressor a bridgeDB:DataSource ;
+	bridgeDB:fullName "AOP-Wiki Stressor" ;
+	bridgeDB:systemCode "AopS" ;
+	bridgeDB:mainUrl "https://aopwiki.org/stressors" ;
+	bridgeDB:idExample "222" ;
+	bridgeDB:primary "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+	bridgeDB:type "metabolite" ;
+	bridgeDB:hasRegexPattern "^\d+$" ;
+	dcterms:alternative "Stressor" .
+
 bridgeDB:Organism_Ag a bridgeDB:Organism ;
 	bridgeDB:code "Ag" ;
 	bridgeDB:shortName "Mosquito" ;

--- a/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.txt
+++ b/org.bridgedb.rdf/resources/IdentifiersOrgDataSource.txt
@@ -19,6 +19,10 @@ Animal Genome Pig QTL	pigqtldb		http://www.animalgenome.org/cgi-bin/QTLdb/SS/qde
 Animal Genome Sheep QTL	sheepqtldb		http://www.animalgenome.org/cgi-bin/QTLdb/OA/qdetails?QTL_ID=$id	19803	unknown		1	urn:miriam:sheepqtldb	^\d+$	
 Animal TFDB Family	atfdb.family		http://www.bioguo.org/AnimalTFDB/family.php?fam=$id	CUT	unknown		1	urn:miriam:atfdb.family	^\w+$	
 AntWeb	antweb		http://www.antweb.org/specimen.do?name=$id	casent0106247	unknown		1	urn:miriam:antweb	^casent\d+(\-D\d+)?$	
+AOP-Wiki KE	AopKe	https://aopwiki.org/	https://aopwiki.org/events/$id	3	unknown		1	urn:miriam:aop.events	^\d+$	AOP-Wiki Key Events
+AOP-Wiki AOP	Aop	https://aopwiki.org/	https://aopwiki.org/aops/$id	3	pathway		1	urn:miriam:aop	^\d+$	AOP-Wiki Adverse Outcome Pathway
+AOP-Wiki KER	AopKer	https://aopwiki.org/	https://aopwiki.org/relationships/$id	5	interaction		1	urn:miriam:aop.relationships	^\d+$	AOP-Wiki Key Event Relationships
+AOP-Wiki Stressor	AopS	https://aopwiki.org/	https://aopwiki.org/stressors/	222	metabolite		1	urn:miriam:aop.stressor	^\d+$	AOP-Wiki Stressor
 APD	apd		http://aps.unmc.edu/AP/database/query_output.php?ID=$id	01001	unknown		1	urn:miriam:apd	^\d{5}$	
 AphidBase Transcript	aphidbase.transcript		http://isyip.genouest.org/apps/grs-2.2/grs?reportID=aphidbase_transcript_report&objectID=$id	ACYPI000159	unknown		1	urn:miriam:aphidbase.transcript	^ACYPI\d{6}(-RA)?$	
 ArachnoServer	arachnoserver		http://www.arachnoserver.org/toxincard.html?id=$id	AS000060	unknown		1	urn:miriam:arachnoserver	^AS\d{6}$	


### PR DESCRIPTION
In order to have AOP-Wiki linkouts in WikiPathways, a couple of resources should be added to BridgeDb. This allows meta-pathways of AOPs, which contain Key Events and Key Event Relationships, and these are initiated by Stressors. So, in total, 4 AOP-related elements should be added. All of these have persistent identifiers, registered on identifiers.org. 
These identifiers allow the linkout from WikiPathways to AOP-Wiki, which contains additional information on the pathway that is represented.