### PR TITLE
resolving launcher.execute error

### DIFF
--- a/org.bridgedb.rdb/pom.xml
+++ b/org.bridgedb.rdb/pom.xml
@@ -98,8 +98,8 @@
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.2.0</version>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
@egonw ; based on one of your commits (https://github.com/bridgedb/BridgeDb/commit/10e01a54a2454df838f7a23b097c5702ab72e639) and work done by @hbasaric , I had an error in Eclipse which I resolved with this change to the pom.xml :smile: 

The error read: 
```
java.lang.NoSuchMethodError: 'void org.junit.platform.launcher.Launcher.execute(org.junit.platform.launcher.TestPlan, org.junit.platform.launcher.TestExecutionListener[])
```

I have only made the change for one libraries pom.xml, it might be that this change is needed for all other libraries too, but I think you would need to check if my change works for you.

