### PR TITLE
fix .bridge file loading by encoding  brackets  using toURI().toString()

### DIFF
--- a/org.bridgedb.gui/src/org/bridgedb/gui/PgdbParameterModel.java
+++ b/org.bridgedb.gui/src/org/bridgedb/gui/PgdbParameterModel.java
@@ -30,7 +30,7 @@ public class PgdbParameterModel extends SimpleParameterModel implements BridgeDb
 	@Override
 	public String getConnectionString()
 	{
-		return "idmapper-pgdb:" + getFile(0).getAbsolutePath();
+		return "idmapper-pgdb:" + getFile(0).toURI().toString();
 	}
 
 	@Override
@@ -43,7 +43,7 @@ public class PgdbParameterModel extends SimpleParameterModel implements BridgeDb
 	public String getHelpHtml()
 	{
 		return 
-			"<html><h1>BridgeDerby database" +
+			"<html><h1>BridgeDerby database" 
 			"<p>BridgeDerby are databases that consist of a single file which you can download " +
 			"to your computer for fast access. Once downloaded, BridgeDerby databases are much" +
 			"faster than a webservice." +

--- a/org.bridgedb.gui/src/org/bridgedb/gui/PgdbParameterModel.java
+++ b/org.bridgedb.gui/src/org/bridgedb/gui/PgdbParameterModel.java
@@ -43,7 +43,7 @@ public class PgdbParameterModel extends SimpleParameterModel implements BridgeDb
 	public String getHelpHtml()
 	{
 		return 
-			"<html><h1>BridgeDerby database" 
+			"<html><h1>BridgeDerby database" +
 			"<p>BridgeDerby are databases that consist of a single file which you can download " +
 			"to your computer for fast access. Once downloaded, BridgeDerby databases are much" +
 			"faster than a webservice." +


### PR DESCRIPTION
BridgeDb loading issues #211

The issue was that when a .bridge file was being downloaded twice, Windows would automatically add (1) to the file name and the plugin was unable to load it.

Solution: .toURI().toString(); encodes the parantheses from special character to %28 and %29. This would also encode (space) in the file name as %20, thus in case a file would have space in its name, it will still be loaded.

( is encoded as %28 
) is encoded as %29 
(space) is encoded as %20

Now, the BridgeDb files can load successfully.
@egonw @DeniseSl22 

<img width="472" height="75" alt="Screenshot 2026-03-23 210120" src="https://github.com/user-attachments/assets/6d14c5f0-b4d9-4820-97e5-5135a6be91e9" />
